### PR TITLE
Moved frame onwership back to the renderer

### DIFF
--- a/Includes/Chicane/Core/Event/Observable.hpp
+++ b/Includes/Chicane/Core/Event/Observable.hpp
@@ -26,7 +26,7 @@ namespace Chicane
         inline ~EventObservable() { m_subscriptions.clear(); }
 
     public:
-        inline EventSubscription<T> subscribe(
+        [[nodiscard]] inline EventSubscription<T> subscribe(
             EmptyCallback inNext, ErrorCallback inError = nullptr, CompleteCallback inComplete = nullptr
         )
         {
@@ -35,7 +35,7 @@ namespace Chicane
             return m_subscriptions.back();
         }
 
-        inline EventSubscription<T> subscribe(
+        [[nodiscard]] inline EventSubscription<T> subscribe(
             NextCallback inNext, ErrorCallback inError = nullptr, CompleteCallback inComplete = nullptr
         )
         {

--- a/Includes/Chicane/Core/Window.hpp
+++ b/Includes/Chicane/Core/Window.hpp
@@ -14,8 +14,11 @@ namespace Chicane
     using WindowEventObservable   = EventObservable<WindowEvent>;
     using WindowEventSubscription = EventSubscription<WindowEvent>;
 
-    using WindowSizeObservable   = EventObservable<Vec<2, int>>;
-    using WindowSizeSubscription = EventSubscription<Vec<2, int>>;
+    using WindowSizeObservable   = EventObservable<Vec<2, std::uint32_t>>;
+    using WindowSizeSubscription = EventSubscription<Vec<2, std::uint32_t>>;
+
+    using WindowBackendObservable   = EventObservable<WindowBackend>;
+    using WindowBackendSubscription = EventSubscription<WindowBackend>;
 
     class Application;
 
@@ -37,12 +40,12 @@ namespace Chicane
         void setTitle(const String& inTitle);
         void setIcon(const FileSystem::Path& inPath);
 
-        const Vec<2, int>& getSize() const;
-        void setSize(const Vec<2, int>& inValue);
+        const Vec<2, std::uint32_t>& getSize() const;
+        void setSize(const Vec<2, std::uint32_t>& inValue);
         void setSize(int inWidth, int inHeight);
 
-        const Vec<2, int>& getPosition() const;
-        void setPosition(const Vec<2, int>& inValue);
+        const Vec<2, std::uint32_t>& getPosition() const;
+        void setPosition(const Vec<2, std::uint32_t>& inValue);
         void setPosition(int inX, int inY);
 
         std::uint32_t getDisplay() const;
@@ -81,6 +84,11 @@ namespace Chicane
             WindowSizeSubscription::ErrorCallback    inError    = nullptr,
             WindowSizeSubscription::CompleteCallback inComplete = nullptr
         );
+        WindowBackendSubscription watchBackend(
+            WindowBackendSubscription::NextCallback     inNext,
+            WindowBackendSubscription::ErrorCallback    inError    = nullptr,
+            WindowBackendSubscription::CompleteCallback inComplete = nullptr
+        );
 
     protected:
         void setBackend(WindowBackend inBackend);
@@ -95,15 +103,16 @@ namespace Chicane
         void emmitError(const String& inMessage);
 
     private:
-        void*                 m_instance;
+        void*                   m_instance;
 
-        WindowSettings        m_settings;
+        WindowSettings          m_settings;
 
-        bool                  m_bIsFocused;
-        bool                  m_bIsResizable;
-        bool                  m_bIsMinimized; // Only takes effect when the type is `WindowType::Windowed`
+        bool                    m_bIsFocused;
+        bool                    m_bIsResizable;
+        bool                    m_bIsMinimized; // Only takes effect when the type is `WindowType::Windowed`
 
-        WindowEventObservable m_eventObservable;
-        WindowSizeObservable  m_sizeObservable;
+        WindowEventObservable   m_eventObservable;
+        WindowSizeObservable    m_sizeObservable;
+        WindowBackendObservable m_backendObservable;
     };
 }

--- a/Includes/Chicane/Core/Window/Settings.hpp
+++ b/Includes/Chicane/Core/Window/Settings.hpp
@@ -14,12 +14,12 @@ namespace Chicane
     struct CHICANE_CORE WindowSettings
     {
     public:
-        String           title    = "";
-        FileSystem::Path icon     = "";
-        Vec<2, int>      size     = Vec<2, int>(0);
-        Vec<2, int>      position = Vec<2, int>(0);
-        std::uint32_t    display  = 0;
-        WindowType       type     = WindowType::Windowed;
-        WindowBackend    backend  = WindowBackend::Undefined;
+        String                title    = "";
+        FileSystem::Path      icon     = "";
+        Vec<2, std::uint32_t> size     = Vec<2, std::uint32_t>(0);
+        Vec<2, std::uint32_t> position = Vec<2, std::uint32_t>(0);
+        std::uint32_t         display  = 0;
+        WindowType            type     = WindowType::Windowed;
+        WindowBackend         backend  = WindowBackend::Undefined;
     };
 }

--- a/Includes/Chicane/Grid/Component/View.hpp
+++ b/Includes/Chicane/Grid/Component/View.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Chicane/Core/String.hpp"
+#include "Chicane/Core/Window.hpp"
 
 #include "Chicane/Grid.hpp"
 #include "Chicane/Grid/Component.hpp"
@@ -31,17 +32,27 @@ namespace Chicane
             void activate();
             void deactivate();
 
-            // Event
-            void handle(WindowEvent inEvent);
+            // Window
+            void setWindow(Window* inWindow);
 
             // Children
             std::vector<Component*> getFlatChildren(const Component* inParent = nullptr) const;
             std::vector<Component*> getChildrenOn(const Vec2& inLocation) const;
 
         protected:
-            String            m_path;
+            // Window
+            void handle(const WindowEvent& inEvent);
 
-            StyleSource::List m_styles;
+        protected:
+            // Window
+            const Window*           m_window;
+            WindowEventSubscription m_windowEventSubscription;
+
+            // Routing
+            String                  m_path;
+
+            // Styling
+            StyleSource::List       m_styles;
         };
     }
 }

--- a/Includes/Chicane/Renderer/Backend.hpp
+++ b/Includes/Chicane/Renderer/Backend.hpp
@@ -19,8 +19,8 @@ namespace Chicane
         class CHICANE_RENDERER Backend
         {
         public:
-            inline Backend(const Window* inWindow)
-                : m_window(inWindow),
+            inline Backend()
+                : m_window(nullptr),
                   m_frames({}),
                   m_currentFrame(0U),
                   m_layers({})
@@ -29,7 +29,9 @@ namespace Chicane
             inline virtual ~Backend() = default;
 
         public:
-            inline virtual void onInit()
+            inline virtual void onInit() { return; }
+
+            inline virtual void onResize(const Vec<2, std::uint32_t>& inResolution)
             {
                 for (Layer<F>* layer : m_layers)
                 {
@@ -38,20 +40,15 @@ namespace Chicane
                         continue;
                     }
 
-                    layer->init();
-                }
-            }
-
-            inline virtual void onResize(const Viewport& inViewport)
-            {
-                for (Layer<F>* layer : m_layers)
-                {
-                    if (!layer)
+                    if (inResolution.x > 0 && inResolution.y > 0)
                     {
-                        continue;
+                        Viewport viewport = layer->getViewport();
+                        viewport.size     = inResolution;
+
+                        layer->setViewport(viewport);
                     }
 
-                    layer->resize(inViewport);
+                    layer->resize(inResolution);
                 }
             }
 
@@ -149,6 +146,9 @@ namespace Chicane
             }
 
         public:
+            // Window
+            inline void setWindow(const Window* inWindow) { m_window = inWindow; }
+
             // Frame
             inline F& getCurrentFrame() { return m_frames.at(m_currentFrame); }
 

--- a/Includes/Chicane/Renderer/Backend/OpenGL.hpp
+++ b/Includes/Chicane/Renderer/Backend/OpenGL.hpp
@@ -18,6 +18,7 @@ namespace Chicane
             void onInit() override;
             void onLoad(const DrawTexture::List& inResources) override;
             void onSetup() override;
+            void onRender(const Frame& inFrame);
             void onCleanup() override;
 
         private:

--- a/Includes/Chicane/Renderer/Backend/OpenGL.hpp
+++ b/Includes/Chicane/Renderer/Backend/OpenGL.hpp
@@ -11,7 +11,7 @@ namespace Chicane
         class CHICANE_RENDERER OpenGLBackend : public Backend<Frame>
         {
         public:
-            OpenGLBackend(const Window* inWindow);
+            OpenGLBackend();
             virtual ~OpenGLBackend();
 
         protected:

--- a/Includes/Chicane/Renderer/Backend/Vulkan.hpp
+++ b/Includes/Chicane/Renderer/Backend/Vulkan.hpp
@@ -20,12 +20,12 @@ namespace Chicane
         class CHICANE_RENDERER VulkanBackend : public Backend<Frame>
         {
         public:
-            VulkanBackend(const Window* inWindow);
+            VulkanBackend();
             virtual ~VulkanBackend();
 
         protected:
             void onInit() override;
-            void onResize(const Viewport& inViewport) override;
+            void onResize(const Vec<2, std::uint32_t>& inResolution) override;
             void onLoad(const DrawTexture::List& inResources) override;
             void onRender() override;
 

--- a/Includes/Chicane/Renderer/Backend/Vulkan.hpp
+++ b/Includes/Chicane/Renderer/Backend/Vulkan.hpp
@@ -27,7 +27,7 @@ namespace Chicane
             void onInit() override;
             void onResize(const Vec<2, std::uint32_t>& inResolution) override;
             void onLoad(const DrawTexture::List& inResources) override;
-            void onRender() override;
+            void onRender(const Frame& inFrame) override;
 
             void onHandle(const WindowEvent& inEvent) override;
 
@@ -59,7 +59,6 @@ namespace Chicane
             void renderViewport(const vk::CommandBuffer& inCommandBuffer);
 
             void buildLayers();
-            void renderLayers(void* inData);
 
             void buildTextureDescriptor();
             void buildTextureData(const DrawTexture::List& inTextures);

--- a/Includes/Chicane/Renderer/Backend/Vulkan/Frame.hpp
+++ b/Includes/Chicane/Renderer/Backend/Vulkan/Frame.hpp
@@ -20,8 +20,8 @@ namespace Chicane
         {
         public:
             // Lifecycle
-            void wait(const vk::Device& inLogicalDevice);
-            void reset(const vk::Device& inLogicalDevice);
+            void wait();
+            void reset();
             void destroy();
 
             // Buffer

--- a/Includes/Chicane/Renderer/Draw/Poly/Type.hpp
+++ b/Includes/Chicane/Renderer/Draw/Poly/Type.hpp
@@ -9,7 +9,8 @@ namespace Chicane
         enum class DrawPolyType : std::uint8_t
         {
             e2D,
-            e3D
+            e3D,
+            eParticle
         };
     }
 }

--- a/Includes/Chicane/Renderer/Frame.hpp
+++ b/Includes/Chicane/Renderer/Frame.hpp
@@ -21,17 +21,15 @@ namespace Chicane
         struct CHICANE_RENDERER Frame
         {
         public:
-            // Lifecycle
             void reset();
             void setup(const DrawPolyResource::Map& inResources);
             void setup(const DrawSky& inResource);
 
-            // Properties
             const View& getCamera() const;
             void useCamera(const View& inData);
 
             const View::List& getLights() const;
-            void addLights(const View::List& inData);
+            void addLight(const View::List& inData);
             void addLight(const View& inData);
 
             const DrawPoly::List& get2DDraws() const;
@@ -61,12 +59,14 @@ namespace Chicane
 
             // Poly
             DrawPoly::Map m_draws = {
-                {DrawPolyType::e2D, {}},
-                {DrawPolyType::e3D, {}}
+                {DrawPolyType::e2D,       {}},
+                {DrawPolyType::e3D,       {}},
+                {DrawPolyType::eParticle, {}}
             };
+
+            // Instances
             DrawPoly2DInstance::Map m_2DInstances = {};
             DrawPoly3DInstance::Map m_3DInstances = {};
-
             DrawSkyInstance         m_skyInstance = {};
         };
     }

--- a/Includes/Chicane/Renderer/Instance.hpp
+++ b/Includes/Chicane/Renderer/Instance.hpp
@@ -48,6 +48,10 @@ namespace Chicane
             void addLight(const View& inData);
             void addLight(const View::List& inData);
 
+            // Frame
+            void setFrameCount(std::uint32_t inValue);
+            Frame& getCurrentFrame();
+
             // Render
             Draw::Id loadPoly(DrawPolyType inType, const DrawPolyData& inData);
 
@@ -67,7 +71,7 @@ namespace Chicane
             template <typename T>
             inline void drawPoly(Draw::Id inId, const T& inInstance)
             {
-                m_backend->drawPoly(inId, inInstance);
+                getCurrentFrame().use(inId, inInstance);
             }
 
             Draw::Id findTexture(const Draw::Reference& inReference);
@@ -105,14 +109,18 @@ namespace Chicane
             DrawPolyResource& getPolyResource(DrawPolyType inType);
 
         private:
+            // Settings
+            Vec<2, std::uint32_t>      m_resolution;
+            ResolutionObservable       m_resolutionObservable;
+
+            // Frame
+            std::vector<Frame>         m_frames;
+            std::uint32_t              m_currentFrame;
+
             // Draw
             DrawPolyResource::Map      m_polyResources;
             DrawTexture::List          m_textureResources;
             DrawSky                    m_skyResource;
-
-            // Settings
-            Vec<2, std::uint32_t>      m_resolution;
-            ResolutionObservable       m_resolutionObservable;
 
             // Backend
             std::unique_ptr<Backend<>> m_backend;

--- a/Includes/Chicane/Renderer/Instance.hpp
+++ b/Includes/Chicane/Renderer/Instance.hpp
@@ -28,14 +28,8 @@ namespace Chicane
 
     namespace Renderer
     {
-        using ResolutionObservable   = EventObservable<Vec<2, int>>;
-        using ResolutionSubscription = EventSubscription<Vec<2, int>>;
-
-        using ViewportObservable   = EventObservable<Viewport>;
-        using ViewportSubscription = EventSubscription<Viewport>;
-
-        using BackendObservable   = EventObservable<WindowBackend>;
-        using BackendSubscription = EventSubscription<WindowBackend>;
+        using ResolutionObservable   = EventObservable<Vec<2, std::uint32_t>>;
+        using ResolutionSubscription = EventSubscription<Vec<2, std::uint32_t>>;
 
         class CHICANE_RENDERER Instance
         {
@@ -43,13 +37,11 @@ namespace Chicane
 
         public:
             Instance();
-            ~Instance();
 
         public:
             // Lifecycle
-            void init(Window* inWindow, WindowBackend inBackend, const Settings& inSettings);
+            void init(const Settings& inSettings);
             void render();
-            void destroy();
 
             // View
             void useCamera(const View& inData);
@@ -85,31 +77,13 @@ namespace Chicane
             Draw::Id loadSky(const DrawSkyData& inData);
 
             // Settings
-            const Vec<2, int>& getResolution() const;
-            void setResolution(const Vec<2, int>& inValue);
+            const Vec<2, std::uint32_t>& getResolution() const;
+            void setResolution(const Vec<2, std::uint32_t>& inValue);
             ResolutionSubscription watchResolution(
                 ResolutionSubscription::NextCallback     inNext,
                 ResolutionSubscription::ErrorCallback    inError    = nullptr,
                 ResolutionSubscription::CompleteCallback inComplete = nullptr
             );
-
-            const Viewport& getViewport() const;
-            void setViewport(const Viewport& inValue);
-            void setViewport(const Vec2& inPosition, const Vec2& inSize);
-            void setViewportPosition(const Vec2& inPosition);
-            void setViewportPosition(float inX, float inY);
-            void setViewportSize(const Vec2& inSize);
-            void setViewportSize(float inWidth, float inHeight);
-            ViewportSubscription watchViewport(
-                ViewportSubscription::NextCallback     inNext,
-                ViewportSubscription::ErrorCallback    inError    = nullptr,
-                ViewportSubscription::CompleteCallback inComplete = nullptr
-            );
-
-            // Window
-            Window* getWindow() const;
-            void setWindow(Window* inWindow);
-            void handle(const WindowEvent& inEvent);
 
             // Backend
             bool hasBackend() const;
@@ -120,44 +94,28 @@ namespace Chicane
                 m_backend->addLayer<Target>(inSettings, inParams...);
             }
 
-            BackendSubscription watchBackend(
-                BackendSubscription::NextCallback     inNext,
-                BackendSubscription::ErrorCallback    inError    = nullptr,
-                BackendSubscription::CompleteCallback inComplete = nullptr
-            );
-
         protected:
-            void setBackend(WindowBackend inType);
+            // Window
+            void handle(const WindowEvent& inEvent);
 
-        private:
+            // Backend
+            void reloadBackend(const Window* inWindow);
+
             // Draw
             DrawPolyResource& getPolyResource(DrawPolyType inType);
-            void reloadResources();
-
-            // Settings
-            void refreshViewport();
-            void propagateResize();
 
         private:
-            // Window
-            Window*                    m_window;
-
             // Draw
             DrawPolyResource::Map      m_polyResources;
             DrawTexture::List          m_textureResources;
             DrawSky                    m_skyResource;
 
             // Settings
-            Vec<2, int>                m_resolution;
+            Vec<2, std::uint32_t>      m_resolution;
             ResolutionObservable       m_resolutionObservable;
-
-            Viewport                   m_viewport;
-            ViewportObservable         m_viewportObservable;
 
             // Backend
             std::unique_ptr<Backend<>> m_backend;
-            WindowBackend              m_backendType;
-            BackendObservable          m_backendObservable;
         };
     }
 }

--- a/Includes/Chicane/Renderer/Layer.hpp
+++ b/Includes/Chicane/Renderer/Layer.hpp
@@ -137,19 +137,21 @@ namespace Chicane
                 onLoad(inResource);
             }
 
-            inline void setup(const F& inFrame)
+            inline bool setup(const F& inFrame)
             {
                 if (!is(LayerStatus::Running))
                 {
-                    return;
+                    return false;
                 }
 
                 if (!onSetup(inFrame))
                 {
-                    return;
+                    return false;
                 }
 
                 setStatus(LayerStatus::Running);
+
+                return true;
             }
 
             inline void render(const F& inFrame, void* inData = nullptr)

--- a/Includes/Chicane/Renderer/Layer.hpp
+++ b/Includes/Chicane/Renderer/Layer.hpp
@@ -41,7 +41,7 @@ namespace Chicane
             inline virtual bool onInit() { return true; }
             inline virtual bool onDestroy() { return true; }
             inline virtual bool onRebuild() { return true; }
-            inline virtual void onResize(const Viewport& inViewport) { return; }
+            inline virtual void onResize(const Vec<2, std::uint32_t>& inResolution) { return; }
             inline virtual void onLoad(DrawPolyType inType, const DrawPolyResource& inResource) { return; }
             inline virtual void onLoad(const DrawTexture::List& inResources) { return; }
             inline virtual void onLoad(const DrawSky& inResource) { return; }
@@ -97,14 +97,14 @@ namespace Chicane
                 setStatus(LayerStatus::Running);
             }
 
-            inline void resize(const Viewport& inViewport)
+            inline void resize(const Vec<2, std::uint32_t>& inResolution)
             {
                 if (is(LayerStatus::Offline))
                 {
                     return;
                 }
 
-                onResize(inViewport);
+                onResize(inResolution);
             }
 
             inline void load(DrawPolyType inType, const DrawPolyResource& inResource)
@@ -175,11 +175,15 @@ namespace Chicane
             inline void handle(const WindowEvent& inEvent) { onEvent(inEvent); }
 
         public:
+            inline const String& getId() const { return m_id; }
+
             inline bool is(LayerStatus inStatus) const { return m_status == inStatus; }
 
             inline void setStatus(LayerStatus inStatus) { m_status = inStatus; }
 
-            inline const String& getId() const { return m_id; }
+            inline const Viewport& getViewport() const { return m_viewport; }
+
+            inline void setViewport(const Viewport& inValue) { m_viewport = inValue; }
 
             template <typename T>
             inline T* getBackend()
@@ -192,7 +196,7 @@ namespace Chicane
         protected:
             Id          m_id;
             LayerStatus m_status;
-
+            Viewport    m_viewport;
             void*       m_backend;
         };
     }

--- a/Includes/Chicane/Renderer/Settings.hpp
+++ b/Includes/Chicane/Renderer/Settings.hpp
@@ -13,7 +13,8 @@ namespace Chicane
         struct CHICANE_RENDERER Settings
         {
         public:
-            Vec<2, std::uint32_t> resolution = Vec<2, std::uint32_t>(0U);
+            Vec<2, std::uint32_t> resolution  = Vec<2, std::uint32_t>(0U);
+            std::uint32_t         bufferCount = 2;
         };
     }
 }

--- a/Includes/Chicane/Renderer/Settings.hpp
+++ b/Includes/Chicane/Renderer/Settings.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstdint>
+
 #include "Chicane/Core/Math/Vec.hpp"
 
 #include "Chicane/Renderer.hpp"
@@ -11,7 +13,7 @@ namespace Chicane
         struct CHICANE_RENDERER Settings
         {
         public:
-            Vec<2, int> resolution = Vec<2, int>(-1);
+            Vec<2, std::uint32_t> resolution = Vec<2, std::uint32_t>(0U);
         };
     }
 }

--- a/Includes/Chicane/Runtime/Application.hpp
+++ b/Includes/Chicane/Runtime/Application.hpp
@@ -105,7 +105,7 @@ namespace Chicane
 
             return static_cast<T*>(m_scene.get());
         }
-        template <class T = Grid::View, typename... Params>
+        template <class T, typename... Params>
         void setView(Params... inParams)
         {
             if (hasView())
@@ -115,8 +115,12 @@ namespace Chicane
             }
 
             m_view = std::make_unique<T>(inParams...);
-            m_view->setSize(m_window->getSize());
             m_view->activate();
+
+            if (hasRenderer())
+            {
+                m_view->setSize(m_renderer->getResolution());
+            }
 
             m_viewObservable.next(m_view.get());
         }
@@ -137,8 +141,8 @@ namespace Chicane
 
     private:
         // Initialization
+        void initRenderer(const Renderer::Settings& inSettings);
         void initWindow(const WindowSettings& inSettings);
-        void initRenderer(WindowBackend inBackend, const Renderer::Settings& inSettings);
         void initBox();
         void initKerb();
 

--- a/Includes/Chicane/Runtime/Scene/Component/Camera.hpp
+++ b/Includes/Chicane/Runtime/Scene/Component/Camera.hpp
@@ -9,5 +9,8 @@ namespace Chicane
     {
     public:
         CCamera();
+
+    public:
+        void onResize(const Vec<2, std::uint32_t>& inSize) override;
     };
 }

--- a/Includes/Chicane/Runtime/Scene/Component/View.hpp
+++ b/Includes/Chicane/Runtime/Scene/Component/View.hpp
@@ -13,6 +13,9 @@ namespace Chicane
     public:
         CView();
 
+    public:
+        inline virtual void onResize(const Vec<2, std::uint32_t>& inValue) { return; }
+
     protected:
         void onTransform() override;
 

--- a/Scripts/Documentation.py
+++ b/Scripts/Documentation.py
@@ -155,6 +155,18 @@ def namespace_to_snake(text, character = "_"):
 
     return text.replace("::", character).upper()
 
+def merge_node(existing, value):
+    for key, val in value.items():
+        if key != "source":
+            existing[key] = val
+            continue
+
+        for src_key, src_val in val.items():
+            if isinstance(src_val, list):
+                existing["source"][src_key].extend(src_val)
+            elif src_val is not None:
+                existing["source"][src_key] = src_val
+
 def add_node(tree, parts, value, accumulated_path = ""):
     part = parts[0]
     path = accumulated_path + part
@@ -181,7 +193,7 @@ def add_node(tree, parts, value, accumulated_path = ""):
         tree.append(existing)
 
     if len(parts) == 1:
-        existing.update(value)
+        merge_node(existing, value)
     else:
         add_node(existing["children"], parts[1:], value, path + "/")
 
@@ -279,7 +291,7 @@ def add_definition(result, compounddef, base_key = ""):
 
     key = header.split(include_dir)[-1].split(".")[0]
 
-    print(get_definition(result, namespace), namespace, header)
+    print(namespace, header)
 
     for sectiondef in compounddef.findall('sectiondef'):
         for memberdef in sectiondef.findall('memberdef'):

--- a/Sources/Editor/Application.cpp
+++ b/Sources/Editor/Application.cpp
@@ -27,7 +27,7 @@ namespace Editor
         // Window
         createInfo.window.title   = "Chicane Editor";
         createInfo.window.icon    = "Contents/Editor/Icon.png";
-        createInfo.window.size    = Chicane::Vec<2, int>(1600, 900);
+        createInfo.window.size    = Chicane::Vec<2, std::uint32_t>(1600, 900);
         createInfo.window.display = 0;
         createInfo.window.type    = Chicane::WindowType::Windowed;
         createInfo.window.backend = Chicane::WindowBackend::OpenGL;
@@ -63,7 +63,7 @@ namespace Editor
 
     void Application::initLayers()
     {
-        Chicane::Application::getInstance().getRenderer()->watchBackend(
+        Chicane::Application::getInstance().getWindow()->watchBackend(
             [](Chicane::WindowBackend inValue)
             {
                 Chicane::ListPush<Chicane::Renderer::Layer<>*> settings;

--- a/Sources/Editor/Layer/OpenGL/Grid.cpp
+++ b/Sources/Editor/Layer/OpenGL/Grid.cpp
@@ -12,12 +12,14 @@ namespace Editor
 
     OpenGLLGrid::~OpenGLLGrid()
     {
+        destroyVertexArray();
         destroyShader();
     }
 
     bool OpenGLLGrid::onInit()
     {
         buildShader();
+        buildVertexArray();
 
         return true;
     }
@@ -36,6 +38,8 @@ namespace Editor
 
         glEnable(GL_BLEND);
         glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+        glBindVertexArray(m_vertexArray);
 
         glDrawArrays(GL_TRIANGLES, 0, 6);
     }
@@ -112,5 +116,15 @@ namespace Editor
     void OpenGLLGrid::destroyShader()
     {
         glDeleteProgram(m_shaderProgram);
+    }
+
+    void OpenGLLGrid::buildVertexArray()
+    {
+        glCreateVertexArrays(1, &m_vertexArray);
+    }
+
+    void OpenGLLGrid::destroyVertexArray()
+    {
+        glDeleteVertexArrays(1, &m_vertexArray);
     }
 }

--- a/Sources/Editor/Layer/OpenGL/Grid.hpp
+++ b/Sources/Editor/Layer/OpenGL/Grid.hpp
@@ -20,8 +20,14 @@ namespace Editor
         void buildShader();
         void destroyShader();
 
+        void buildVertexArray();
+        void destroyVertexArray();
+
     private:
         // Shader
         std::uint32_t m_shaderProgram;
+
+        // Buffer
+        std::uint32_t m_vertexArray;
     };
 }

--- a/Sources/Engine/Grid/Component/View.cpp
+++ b/Sources/Engine/Grid/Component/View.cpp
@@ -11,6 +11,9 @@ namespace Chicane
     {
         View::View(const String& inSource)
             : Component(TAG_ID),
+              m_window(nullptr),
+              m_windowEventSubscription({}),
+              m_path(""),
               m_styles({})
         {
             if (inSource.isEmpty())
@@ -71,27 +74,18 @@ namespace Chicane
             onDeactivation();
         }
 
-        void View::handle(WindowEvent inEvent)
+        void View::setWindow(Window* inWindow)
         {
-            if (inEvent.type == WindowEventType::MouseButtonDown)
-            {
-                Input::MouseButtonEvent event = *static_cast<Input::MouseButtonEvent*>(inEvent.data);
+            m_windowEventSubscription.complete();
 
-                for (Component* contender : getChildrenOn(event.location))
-                {
-                    contender->click();
-                }
+            m_window = inWindow;
+
+            if (!m_window)
+            {
+                return;
             }
 
-            if (inEvent.type == WindowEventType::MouseMotion)
-            {
-                Input::MouseMotionEvent event = *static_cast<Input::MouseMotionEvent*>(inEvent.data);
-
-                for (Component* contender : getChildrenOn(event.location))
-                {
-                    contender->hover();
-                }
-            }
+            m_windowEventSubscription = inWindow->watchEvent([this](WindowEvent inEvent) { handle(inEvent); });
         }
 
         std::vector<Component*> View::getFlatChildren(const Component* inParent) const
@@ -143,6 +137,29 @@ namespace Chicane
             );
 
             return contenders;
+        }
+
+        void View::handle(const WindowEvent& inEvent)
+        {
+            if (inEvent.type == WindowEventType::MouseButtonDown)
+            {
+                Input::MouseButtonEvent event = *static_cast<Input::MouseButtonEvent*>(inEvent.data);
+
+                for (Component* contender : getChildrenOn(event.location))
+                {
+                    contender->click();
+                }
+            }
+
+            if (inEvent.type == WindowEventType::MouseMotion)
+            {
+                Input::MouseMotionEvent event = *static_cast<Input::MouseMotionEvent*>(inEvent.data);
+
+                for (Component* contender : getChildrenOn(event.location))
+                {
+                    contender->hover();
+                }
+            }
         }
     }
 }

--- a/Sources/Engine/Renderer/Backend/OpenGL.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL.cpp
@@ -16,11 +16,9 @@ namespace Chicane
     {
         static SDL_GLContext g_context;
 
-        OpenGLBackend::OpenGLBackend(const Window* inWindow)
-            : Backend<Frame>(inWindow)
-        {
-            setFrameCount(2);
-        }
+        OpenGLBackend::OpenGLBackend()
+            : Backend<Frame>()
+        {}
 
         OpenGLBackend::~OpenGLBackend()
         {
@@ -34,6 +32,8 @@ namespace Chicane
 
         void OpenGLBackend::onInit()
         {
+            setFrameCount(2);
+
             buildContext();
             buildGlew();
             enableFeatures();
@@ -72,9 +72,6 @@ namespace Chicane
 
         void OpenGLBackend::onSetup()
         {
-            //const Viewport& viewport = m_renderer->getViewport();
-            //glViewport(viewport.position.x, viewport.position.y, viewport.size.x, viewport.size.y);
-
             glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
             glClearDepth(1);
 

--- a/Sources/Engine/Renderer/Backend/OpenGL.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL.cpp
@@ -32,8 +32,6 @@ namespace Chicane
 
         void OpenGLBackend::onInit()
         {
-            setFrameCount(2);
-
             buildContext();
             buildGlew();
             enableFeatures();
@@ -77,9 +75,14 @@ namespace Chicane
 
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
 
-            glBindTextureUnit(0, m_texturesBuffer);
+            glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 
-            Backend::onSetup();
+            glBindTextureUnit(0, m_texturesBuffer);
+        }
+
+        void OpenGLBackend::onRender(const Frame& inFrame)
+        {
+            renderLayers(inFrame);
         }
 
         void OpenGLBackend::onCleanup()
@@ -90,8 +93,6 @@ namespace Chicane
             {
                 throw std::runtime_error(std::string("Failed to swawp window frame buffer [") + SDL_GetError() + "]");
             }
-
-            Backend::onCleanup();
         }
 
         void OpenGLBackend::buildContext()

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Grid.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Grid.cpp
@@ -67,6 +67,8 @@ namespace Chicane
 
         void OpenGLLGrid::onRender(const Frame& inFrame, void* inData)
         {
+            glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
+
             glUseProgram(m_shaderProgram);
 
             glClear(GL_DEPTH_BUFFER_BIT);

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Grid.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Grid.cpp
@@ -112,6 +112,7 @@ namespace Chicane
 
         void OpenGLLGrid::onCleanup()
         {
+            glDisable(GL_DEPTH_TEST);
             glDisable(GL_BLEND);
         }
 

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene.cpp
@@ -57,12 +57,7 @@ namespace Chicane
 
         bool OpenGLLScene::onSetup(const Frame& inFrame)
         {
-            if (inFrame.getInstances3D().empty())
-            {
-                return false;
-            }
-
-            if (inFrame.get3DDraws().empty())
+            if (inFrame.get3DDraws().empty() && inFrame.getSkyInstance().model.id == Draw::UnknownId)
             {
                 return false;
             }
@@ -73,8 +68,6 @@ namespace Chicane
         void OpenGLLScene::onRender(const Frame& inFrame, void* inData)
         {
             glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
-
-            glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 
             glBindVertexArray(m_modelVertexArray);
             glVertexArrayElementBuffer(m_modelVertexArray, m_modelIndexBuffer);

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene.cpp
@@ -72,6 +72,8 @@ namespace Chicane
 
         void OpenGLLScene::onRender(const Frame& inFrame, void* inData)
         {
+            glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
+
             glClipControl(GL_LOWER_LEFT, GL_ZERO_TO_ONE);
 
             glBindVertexArray(m_modelVertexArray);

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Mesh.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Mesh.cpp
@@ -36,6 +36,8 @@ namespace Chicane
                 return;
             }
 
+            glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
+
             glUseProgram(m_shaderProgram);
 
             glEnable(GL_DEPTH_TEST);

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Shadow.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Shadow.cpp
@@ -41,6 +41,8 @@ namespace Chicane
                 return;
             }
 
+            glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
+
             glUseProgram(m_shaderProgram);
 
             glBindFramebuffer(GL_FRAMEBUFFER, m_shadowFramebuffer);

--- a/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Sky.cpp
+++ b/Sources/Engine/Renderer/Backend/OpenGL/Layer/Scene/Sky.cpp
@@ -63,6 +63,8 @@ namespace Chicane
                 return;
             }
 
+            glViewport(m_viewport.position.x, m_viewport.position.y, m_viewport.size.x, m_viewport.size.y);
+
             glUseProgram(m_shaderProgram);
 
             glEnable(GL_CULL_FACE);

--- a/Sources/Engine/Renderer/Backend/Vulkan.cpp
+++ b/Sources/Engine/Renderer/Backend/Vulkan.cpp
@@ -19,8 +19,8 @@ namespace Chicane
 {
     namespace Renderer
     {
-        VulkanBackend::VulkanBackend(const Window* inWindow)
-            : Backend<Frame>(inWindow),
+        VulkanBackend::VulkanBackend()
+            : Backend<Frame>(),
               swapchain({}),
               imageCount(0),
               m_currentImageIndex(0),
@@ -51,6 +51,8 @@ namespace Chicane
 
         void VulkanBackend::onInit()
         {
+            setFrameCount(2);
+
             buildInstance();
             buildDebugMessenger();
             buildSurface();
@@ -66,26 +68,21 @@ namespace Chicane
             Backend::onInit();
         }
 
-        void VulkanBackend::onResize(const Viewport& inViewport)
+        void VulkanBackend::onResize(const Vec<2, std::uint32_t>& inResolution)
         {
-            float x = inViewport.position.x;
-            float y = inViewport.position.y;
-            float w = inViewport.size.x;
-            float h = inViewport.size.y;
-
-            viewport.x        = x;
-            viewport.y        = y;
-            viewport.width    = w;
-            viewport.height   = h;
+            viewport.x        = 0.0f;
+            viewport.y        = 0.0f;
+            viewport.width    = inResolution.x;
+            viewport.height   = inResolution.y;
             viewport.minDepth = 0.0f;
             viewport.maxDepth = 1.0f;
 
-            scissor.offset.x      = static_cast<int32_t>(x);
-            scissor.offset.y      = static_cast<int32_t>(y);
-            scissor.extent.width  = static_cast<uint32_t>(w);
-            scissor.extent.height = static_cast<uint32_t>(h);
+            scissor.offset.x      = 0U;
+            scissor.offset.y      = 0U;
+            scissor.extent.width  = static_cast<uint32_t>(viewport.width);
+            scissor.extent.height = static_cast<uint32_t>(viewport.height);
 
-            Backend::onResize(inViewport);
+            Backend::onResize(inResolution);
         }
 
         void VulkanBackend::onLoad(const DrawTexture::List& inResources)

--- a/Sources/Engine/Renderer/Backend/Vulkan/Frame.cpp
+++ b/Sources/Engine/Renderer/Backend/Vulkan/Frame.cpp
@@ -12,9 +12,9 @@ namespace Chicane
 {
     namespace Renderer
     {
-        void VulkanFrame::wait(const vk::Device& inLogicalDevice)
+        void VulkanFrame::wait()
         {
-            vk::Result result = inLogicalDevice.waitForFences(1, &renderFence, VK_TRUE, UINT64_MAX);
+            vk::Result result = logicalDevice.waitForFences(1, &renderFence, VK_TRUE, UINT64_MAX);
 
             if (result != vk::Result::eSuccess && result != vk::Result::eTimeout)
             {
@@ -22,9 +22,9 @@ namespace Chicane
             }
         }
 
-        void VulkanFrame::reset(const vk::Device& inLogicalDevice)
+        void VulkanFrame::reset()
         {
-            vk::Result result = inLogicalDevice.resetFences(1, &renderFence);
+            vk::Result result = logicalDevice.resetFences(1, &renderFence);
 
             if (result != vk::Result::eSuccess)
             {

--- a/Sources/Engine/Renderer/Frame.cpp
+++ b/Sources/Engine/Renderer/Frame.cpp
@@ -55,7 +55,7 @@ namespace Chicane
             return m_lights;
         }
 
-        void Frame::addLights(const View::List& inData)
+        void Frame::addLight(const View::List& inData)
         {
             m_lights.insert(m_lights.begin(), inData.begin(), inData.end());
         }

--- a/Sources/Engine/Renderer/Instance.cpp
+++ b/Sources/Engine/Renderer/Instance.cpp
@@ -13,34 +13,14 @@ namespace Chicane
     namespace Renderer
     {
         Instance::Instance()
-            : m_window(nullptr),
-              m_resolution(Vec<2, int>(0)),
+            : m_resolution(Vec<2, std::uint32_t>(0)),
               m_resolutionObservable({}),
-              m_viewport({}),
-              m_viewportObservable({}),
-              m_backend(nullptr),
-              m_backendType(WindowBackend::Undefined),
-              m_backendObservable({})
+              m_backend(nullptr)
         {}
 
-        Instance::~Instance()
+        void Instance::init(const Settings& inSettings)
         {
-            destroy();
-        }
-
-        void Instance::init(Window* inWindow, WindowBackend inBackend, const Settings& inSettings)
-        {
-            if (!inWindow)
-            {
-                return;
-            }
-
-            // Window
-            setWindow(inWindow);
-
-            // Renderer
             setResolution(inSettings.resolution);
-            setBackend(inBackend);
         }
 
         void Instance::render()
@@ -61,11 +41,6 @@ namespace Chicane
             currentFrame.reset();
 
             getPolyResource(DrawPolyType::e2D).reset();
-        }
-
-        void Instance::destroy()
-        {
-            m_backend.reset();
         }
 
         void Instance::useCamera(const View& inData)
@@ -193,12 +168,12 @@ namespace Chicane
             return m_skyResource.id;
         }
 
-        const Vec<2, int>& Instance::getResolution() const
+        const Vec<2, std::uint32_t>& Instance::getResolution() const
         {
             return m_resolution;
         }
 
-        void Instance::setResolution(const Vec<2, int>& inValue)
+        void Instance::setResolution(const Vec<2, std::uint32_t>& inValue)
         {
             if (m_resolution == inValue)
             {
@@ -207,9 +182,12 @@ namespace Chicane
 
             m_resolution = inValue;
 
-            m_resolutionObservable.next(m_resolution);
+            if (hasBackend())
+            {
+                m_backend->onResize(m_resolution);
+            }
 
-            refreshViewport();
+            m_resolutionObservable.next(m_resolution);
         }
 
         ResolutionSubscription Instance::watchResolution(
@@ -221,160 +199,52 @@ namespace Chicane
             return m_resolutionObservable.subscribe(inNext, inError, inComplete).next(m_resolution);
         }
 
-        const Viewport& Instance::getViewport() const
-        {
-            return m_viewport;
-        }
-
-        void Instance::setViewport(const Viewport& inValue)
-        {
-            setViewport(inValue.position, inValue.size);
-        }
-
-        void Instance::setViewport(const Vec2& inPosition, const Vec2& inSize)
-        {
-            setViewportPosition(inPosition);
-            setViewportSize(inSize);
-        }
-
-        void Instance::setViewportPosition(const Vec2& inPosition)
-        {
-            setViewportPosition(inPosition.x, inPosition.y);
-        }
-
-        void Instance::setViewportPosition(float inX, float inY)
-        {
-            if (std::fabs(m_viewport.position.x - inX) < FLT_EPSILON &&
-                std::fabs(m_viewport.position.y - inY) < FLT_EPSILON)
-            {
-                return;
-            }
-
-            m_viewport.position.x = inX;
-            m_viewport.position.y = inY;
-
-            propagateResize();
-        }
-
-        void Instance::setViewportSize(const Vec2& inSize)
-        {
-            setViewportSize(inSize.x, inSize.y);
-        }
-
-        void Instance::setViewportSize(float inWidth, float inHeight)
-        {
-            if (std::fabs(m_viewport.size.x - inWidth) < FLT_EPSILON &&
-                std::fabs(m_viewport.size.y - inHeight) < FLT_EPSILON)
-            {
-                return;
-            }
-
-            m_viewport.size.x = inWidth;
-            m_viewport.size.y = inHeight;
-
-            propagateResize();
-        }
-
-        ViewportSubscription Instance::watchViewport(
-            ViewportSubscription::NextCallback     inNext,
-            ViewportSubscription::ErrorCallback    inError,
-            ViewportSubscription::CompleteCallback inComplete
-        )
-        {
-            return m_viewportObservable.subscribe(inNext, inError, inComplete).next(m_viewport);
-        }
-
-        Window* Instance::getWindow() const
-        {
-            return m_window;
-        }
-
-        void Instance::setWindow(Window* inWindow)
-        {
-            if (inWindow == m_window)
-            {
-                return;
-            }
-
-            m_window = inWindow;
-            m_window->watchSize([&](const Vec<2, int>& inSize) { refreshViewport(); });
-            m_window->watchEvent([&](WindowEvent inEvent) { handle(inEvent); });
-        }
-
-        void Instance::handle(const WindowEvent& inEvent)
-        {
-            if (!hasBackend())
-            {
-                return;
-            }
-
-            m_backend->onHandle(inEvent);
-        }
-
         bool Instance::hasBackend() const
         {
             return m_backend && m_backend.get() != nullptr;
         }
 
-        BackendSubscription Instance::watchBackend(
-            BackendSubscription::NextCallback     inNext,
-            BackendSubscription::ErrorCallback    inError,
-            BackendSubscription::CompleteCallback inComplete
-        )
+        void Instance::handle(const WindowEvent& inEvent)
         {
-            return m_backendObservable.subscribe(inNext, inError, inComplete).next(m_backendType);
+            if (hasBackend())
+            {
+                m_backend->onHandle(inEvent);
+            }
         }
 
-        void Instance::setBackend(WindowBackend inType)
+        void Instance::reloadBackend(const Window* inWindow)
         {
             if (hasBackend())
             {
                 m_backend.reset();
             }
 
-            switch (inType)
+            switch (inWindow->getBackend())
             {
 #if CHICANE_OPENGL
             case WindowBackend::OpenGL:
-                m_backend = std::make_unique<OpenGLBackend>(m_window);
+                m_backend = std::make_unique<OpenGLBackend>();
 
                 break;
 #endif
 
 #if CHICANE_VULKAN
             case WindowBackend::Vulkan:
-                m_backend = std::make_unique<VulkanBackend>(m_window);
+                m_backend = std::make_unique<VulkanBackend>();
 
                 break;
 #endif
 
             default:
-                m_backend = std::make_unique<Backend<>>(m_window);
+                m_backend = std::make_unique<Backend<>>();
 
                 break;
             }
 
-            m_backend->onResize(m_viewport);
+            m_backend->setWindow(inWindow);
+
             m_backend->onInit();
-
-            m_backendType = inType;
-
-            m_backendObservable.next(m_backendType);
-
-            reloadResources();
-        }
-
-        DrawPolyResource& Instance::getPolyResource(DrawPolyType inType)
-        {
-            return m_polyResources[inType];
-        }
-
-        void Instance::reloadResources()
-        {
-            if (!hasBackend())
-            {
-                return;
-            }
+            m_backend->onResize(m_resolution);
 
             for (const auto& [type, resource] : m_polyResources)
             {
@@ -385,38 +255,9 @@ namespace Chicane
             m_backend->onLoad(m_skyResource);
         }
 
-        void Instance::refreshViewport()
+        DrawPolyResource& Instance::getPolyResource(DrawPolyType inType)
         {
-            if (m_resolution.x == 0 || m_resolution.y == 0)
-            {
-                return;
-            }
-
-            Vec<2, int> windowSize   = getWindow()->getSize();
-            Vec<2, int> rendererSize = m_resolution;
-
-            bool bIsRenderingScalable = rendererSize.x <= 0.0f || rendererSize.y <= 0.0f;
-            bool bIsRenderingUp       = windowSize.x < rendererSize.x || windowSize.y < rendererSize.y;
-
-            if (bIsRenderingUp || bIsRenderingScalable)
-            {
-                rendererSize = windowSize;
-            }
-
-            int scale = std::min(windowSize.x / rendererSize.x, windowSize.y / rendererSize.y);
-
-            setViewportSize(rendererSize * scale);
-            setViewportPosition((windowSize - rendererSize) / 2);
-        }
-
-        void Instance::propagateResize()
-        {
-            m_viewportObservable.next(m_viewport);
-
-            if (hasBackend())
-            {
-                m_backend->onResize(m_viewport);
-            }
+            return m_polyResources[inType];
         }
     }
 }

--- a/Sources/Engine/Runtime/Scene/Component/Camera.cpp
+++ b/Sources/Engine/Runtime/Scene/Component/Camera.cpp
@@ -1,8 +1,15 @@
 #include "Chicane/Runtime/Scene/Component/Camera.hpp"
 
+#include "Chicane/Core/Log.hpp"
+
 namespace Chicane
 {
     CCamera::CCamera()
         : CView()
     {}
+
+    void CCamera::onResize(const Vec<2, std::uint32_t>& inSize)
+    {
+        setViewport(inSize);
+    }
 }

--- a/Sources/Sample/Shooter/Application.cpp
+++ b/Sources/Sample/Shooter/Application.cpp
@@ -13,7 +13,7 @@ Application::Application()
 
     // Window
     createInfo.window.title   = "Shooter Sample";
-    createInfo.window.size    = Chicane::Vec<2, int>(1600, 900);
+    createInfo.window.size    = Chicane::Vec<2, std::uint32_t>(1600, 900);
     createInfo.window.display = 0;
     createInfo.window.type    = Chicane::WindowType::Windowed;
     createInfo.window.backend = Chicane::WindowBackend::OpenGL;


### PR DESCRIPTION
## Description

Turns out there is a difference between Image and Frame in the Vulkan context so I got those things messed up, also, the renderer having control over the frame count its actually good, with that in mind I gave the onwership of the frame back to the renderer.

## Features

- Moved frame ownership back to the renderer;
- Improved documentation node merge logic.
